### PR TITLE
fix: correct image source label, bump-rule false positives, and doc inaccuracies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,9 +26,9 @@ jobs:
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           PATCH=$(echo "$VERSION" | cut -d. -f3)
           COMMIT_MSG=$(git log -1 --pretty=%B)
-          if echo "$COMMIT_MSG" | grep -qiE 'BREAKING'; then
+          if echo "$COMMIT_MSG" | grep -qE 'BREAKING' || echo "$COMMIT_MSG" | grep -qE '^[a-z]+(\(.+\))?!:'; then
             NEW_VERSION="$((MAJOR+1)).0.0"
-          elif echo "$COMMIT_MSG" | grep -qE '^feat(\(.+\))?!?:'; then
+          elif echo "$COMMIT_MSG" | grep -qE '^feat(\(.+\))?:'; then
             NEW_VERSION="${MAJOR}.$((MINOR+1)).0"
           else
             NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH+1))"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,6 @@ src/haruka-aibara-dev-env/
     devcontainer.json                 # VS Code拡張・設定・features定義
     post-create.sh                    # コンテナ作成後セットアップ
 
-.devcontainer/                        # このリポジトリ自体の開発環境（src配下と同内容）
 .github/workflows/release.yaml        # mainへのpushで自動リリース
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Before using this DevContainer template, ensure:
    ~/.gitconfig
    ```
 
-These files will be mounted into the container (read-only) to enable authentication with cloud services and maintain consistent Git commit identity.
+These files will be mounted into the container to enable authentication with cloud services and maintain consistent Git commit identity. The `.aws` and `.gitconfig` mounts are read-only; the `gcloud` directory is mounted writable so the CLI can refresh access tokens.
 
 ## 🔧 Usage
 
@@ -101,7 +101,7 @@ After the container is running, all pre-configured tools are immediately availab
 
 ### Cloud Credentials
 
-Cloud credentials from your host machine are automatically mounted (read-only) into the container.
+Cloud credentials from your host machine are automatically mounted into the container (AWS read-only, gcloud writable for token refresh).
 
 **AWS Credentials**: Verify with:
 ```bash

--- a/src/haruka-aibara-dev-env/.devcontainer/Dockerfile
+++ b/src/haruka-aibara-dev-env/.devcontainer/Dockerfile
@@ -120,4 +120,4 @@ ENV PATH=/home/vscode/.local/bin:$PATH
 # Includes description, licensing, and source repository information
 LABEL org.opencontainers.image.description="Secure development environment for AWS, Terraform, and Python projects"
 LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.source="https://github.com/haruka-aibara/my-devcontainer-template"
+LABEL org.opencontainers.image.source="https://github.com/haruka-aibara/devcontainer-templates"

--- a/src/haruka-aibara-dev-env/.devcontainer/devcontainer.json
+++ b/src/haruka-aibara-dev-env/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
     // Read-only access prevents accidental modification of credentials from within the container
     "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,readonly",
     // Mount Google Cloud credentials from host to container to enable gcloud CLI functionality
-    // Read-only access prevents accidental modification of credentials from within the container
+    // Mounted writable (not readonly) because gcloud needs to refresh access tokens and write logs
     "source=${localEnv:HOME}/.config/gcloud,target=/home/vscode/.config/gcloud,type=bind",
     // Mount Git configuration to maintain consistent commit identity across environments
     // Read-only to ensure container operations cannot modify your global Git settings


### PR DESCRIPTION
## 概要

リポジトリ全体を点検して見つかった問題の修正です。

## 修正内容

### release.yaml: バージョン bump の誤判定（実害あり）
- `grep -qiE 'BREAKING'` が大文字小文字を無視するため、`fix: avoid breaking existing behavior` のような「breaking」を含むだけのコミットで意図せず **major bump** が発生する状態だった。大文字の `BREAKING` のみにマッチするよう修正
- Conventional Commits の `feat!:` / `fix(scope)!:` が minor/patch 扱いだったのを major に修正
- サンプルメッセージ 7 件で新ロジックの動作確認済み

### Dockerfile: OCI ラベルのリポジトリ名誤り
- `org.opencontainers.image.source` が存在しない `haruka-aibara/my-devcontainer-template` を指していたのを `haruka-aibara/devcontainer-templates` に修正（ghcr.io のパッケージとリポジトリの紐付けに使われるラベル）

### devcontainer.json: コメントと実態の不一致
- gcloud マウントのコメントが「Read-only」と説明していたが、実際は `readonly` フラグなし（gcloud のトークン更新のため意図的に書き込み可）。コメント側を実態に合わせて修正

### ドキュメント修正
- README.md: 「全クレデンシャルが read-only マウント」という記述を実態（gcloud のみ書き込み可）に修正
- CLAUDE.md: git 履歴上一度も存在しないルート直下の `.devcontainer/` の記載を削除

## バージョンへの影響

マージコミットが `fix:` プレフィックスのため patch bump（1.1.2 → 1.1.3）で publish されます。

https://claude.ai/code/session_011WVevNQj1wSidNUSD2Re2a

---
_Generated by [Claude Code](https://claude.ai/code/session_011WVevNQj1wSidNUSD2Re2a)_