### PR TITLE
fix: pin devcontainer base image to ubuntu-24.04 LTS

### DIFF
--- a/src/haruka-aibara-dev-env/.devcontainer/Dockerfile
+++ b/src/haruka-aibara-dev-env/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 # Multi-stage build using Ubuntu base image to optimize final image size
-FROM mcr.microsoft.com/devcontainers/base:ubuntu AS builder
+# Pinned to the 24.04 (noble) LTS tag: the floating ":ubuntu" tag now resolves to
+# Ubuntu "resolute" (25.10, non-LTS), where the docker-in-docker feature's "moby"
+# packages (moby-cli etc.) are not yet available and the feature install fails.
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04 AS builder
 
 # System updates and tool installation - combined in a single layer to minimize image size
 # Using --no-install-recommends flag to avoid installing unnecessary packages
@@ -39,7 +42,8 @@ RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/s
     && rm kubectl
 
 # Creating the final optimized image with just the necessary tools
-FROM mcr.microsoft.com/devcontainers/base:ubuntu
+# Pinned to the same 24.04 (noble) LTS tag as the builder stage (see note above).
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 # Copying installed tools from the builder stage to reduce final image size
 # This multi-stage approach prevents build artifacts from bloating the final image


### PR DESCRIPTION
## 概要

devcontainer の起動が `docker-in-docker` feature のインストール失敗で落ちる問題を修正します。

## 原因

ベースイメージの floating タグ `mcr.microsoft.com/devcontainers/base:ubuntu` が、現在 Ubuntu `resolute`（25.10, 非LTS）に解決されるようになりました。この distribution には docker-in-docker feature の `moby` 系パッケージ（`moby-cli` 等）がまだ無いため、feature インストールが失敗します:

```
(!) The 'moby' option is not supported on ubuntu 'resolute' because
    'moby-cli' and related system packages are not available in that distribution.
(!) To continue, either set the feature option '"moby": false' or use a different base image.
ERROR: Feature "Docker (Docker-in-Docker)" failed to install!
```

結果としてイメージビルドが失敗 → コンテナ削除（ログ末尾の `exit 137` / `No such container` はこの後始末）。

## 修正

`Dockerfile` の両ステージの `FROM` を `ubuntu-24.04`（noble, LTS）に固定しました。これにより:

- `devcontainer.json` の `"moby": true`（オープンソース Moby エンジン採用）をそのまま維持できる
- floating タグが非LTSの新バージョンを掴んで再発するのを防げる

固定はベースイメージのみで、Dockerfile 内の各ツールは引き続き latest を動的取得します。

## テスト

- [ ] ローカルで devcontainer の再ビルド・起動が成功することを確認

https://claude.ai/code/session_016dbYvLaDRKjJ5pwWq94DYv

---
_Generated by [Claude Code](https://claude.ai/code/session_016dbYvLaDRKjJ5pwWq94DYv)_